### PR TITLE
Network

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,23 @@
-use super::{SERVER_HOST, SERVER_PORT, CLIENT_PING_PERIOD};
+use super::{CLIENT_PING_PERIOD};
+use std::io::timer;
 use std::io::{TcpStream, Timer};
 
-pub fn main() {
-    let mut stream = TcpStream::connect(SERVER_HOST, SERVER_PORT);
+fn get_stream(host: &str, port: u16) -> TcpStream {
+    println!("connecting to {}:{}", host, port);
+    loop {
+        match TcpStream::connect(host, port) {
+            Ok(stream) => {
+                return stream;
+            },
+            Err(_) => {
+                timer::sleep(1000);
+            }
+        }
+    }
+}
+
+pub fn connect(host: &str, port: u16, msg: &str) {
+    let mut stream = get_stream(host, port);
 
     let mut timer = {
         match Timer::new() {
@@ -16,8 +31,8 @@ pub fn main() {
     let periodic = timer.periodic(CLIENT_PING_PERIOD);
 
     loop {
-        periodic.recv(); 
-        match stream.write_str("hello\n") {
+        periodic.recv();
+        match stream.write_str(msg) {
             Ok(()) => {},
             Err(e) => {println!("{}", e);},
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,62 +1,66 @@
 use std::os;
-use std::io::{TcpListener, TcpStream, Listener, Acceptor};
+use help::{usage, parse_address};
 
 type Address = (String, u16);
-
-fn usage() -> &'static str {
-    "raft bind_address [connect addresses]..."
-}
 
 fn main() {
     let mut args = os::args().move_iter();
     
-    let _ /* executable name */ = args.next();
-    let bind_address = args.next().expect(usage());    
-    let connect_addresses = args.collect();
-    listen_and_connect(bind_address, connect_addresses);
+    let _          = args.next();
+    let bind_addr  = args.next().expect(usage());
+    let conn_addrs = args.collect();
+    network(bind_addr, conn_addrs);
 }
 
-fn listen_and_connect(bind_address: String, connect_addresses: Vec<String>) {
-    let bind_address = parse_address(bind_address).expect("couldn't parse bind address");
-    let connect_addresses = connect_addresses.move_iter().map(|s| {
-        parse_address(s).expect("couldn't parse listen address")
+fn network(bind_addr: String, conn_addrs: Vec<String>) {
+    let bind_addr = parse_address(bind_addr).expect(usage());
+    let conn_addrs = conn_addrs.move_iter().map(|s| {
+        parse_address(s).expect(usage())
     }).collect();
-    lac(bind_address, connect_addresses);
+    
+    _network(bind_addr, conn_addrs);
 }
 
-fn lac(bind_address: Address, connect_addresses: Vec<Address>) {
-    //spawn(proc() {serve(bind_address)});
-    //spawn(proc() {connect(connect_addresses)});
+fn _network(bind_addr: Address, conn_addrs: Vec<Address>) {
+    let _ = bind_addr;
+    let _ = conn_addrs;
+    //spawn(proc() {serve(bind_addr)});
+    //spawn(proc() {connect(conn_addrs)});
 }
 
-fn parse_address(address: String) -> Option<Address> {
-    let hostport: Vec<&str> = address.as_slice().split(':').collect();
-    if hostport.len() < 2 {
-        None
-    } else {
-        let host = hostport[0];
-        let port: u16 = match from_str(hostport[1]) {
-            Some(port) => port,
-            None => {
-                println!("could not parse port");
-                return None;
-            }
-        };
-        Some((String::from_str(host), port))
+mod help {
+    pub fn usage() -> &'static str {
+        "raft bind_addr [connect addresses]..."
+    }
+
+    pub fn parse_address(address: String) -> Option<super::Address> {
+        let hostport: Vec<&str> = address.as_slice().split(':').collect();
+        
+        if hostport.len() < 2 {
+            return None
+        } 
+
+        match (String::from_str(hostport[0]), from_str(hostport[1])) {
+            (host, Some(port)) => Some((host, port)),
+            (_   , None      ) => None,
+        }
     }
 }
 
 #[test]
 fn foo() {
     fn assert(expected: Option<Address>, actual: &str) {
-        let actual = parse_address(String::from_str(actual));
-        assert!(expected == actual);
+        assert_eq!(expected, parse_address(String::from_str(actual)));
     }
+
+    let from = String::from_str;
 
     assert(None, "");
     assert(None, "localhost");
     assert(None, "8080");
     assert(None, "localhost8080");
     assert(None, "localhost:");
-    assert(Some((String::from_str("localhost"), 8080u16)), "localhost:8080");
+    assert(Some((from("localhost"), 8080u16)), "localhost:8080");
+    assert(Some((from("localhost"), 0u16)), "localhost:0");
+    assert(Some((from(""), 0u16)), ":0");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,62 @@
 use std::os;
+use std::io::{TcpListener, TcpStream, Listener, Acceptor};
 
-pub mod server;
-pub mod client;
+type Address = (String, u16);
 
-static SERVER_HOST: &'static str = "127.0.0.1";
-static SERVER_PORT: u16          = 9999;
-
-fn usage() {
-    println!("raft (client|server)");
+fn usage() -> &'static str {
+    "raft bind_address [connect addresses]..."
 }
 
 fn main() {
-    let args = os::args();
+    let mut args = os::args().move_iter();
+    
+    let _ /* executable name */ = args.next();
+    let bind_address = args.next().expect(usage());    
+    let connect_addresses = args.collect();
+    listen_and_connect(bind_address, connect_addresses);
+}
 
-    if args.len() < 2 {
-        usage();
-        os::set_exit_status(1);
-        return;
+fn listen_and_connect(bind_address: String, connect_addresses: Vec<String>) {
+    let bind_address = parse_address(bind_address).expect("couldn't parse bind address");
+    let connect_addresses = connect_addresses.move_iter().map(|s| {
+        parse_address(s).expect("couldn't parse listen address")
+    }).collect();
+    lac(bind_address, connect_addresses);
+}
+
+fn lac(bind_address: Address, connect_addresses: Vec<Address>) {
+    //spawn(proc() {serve(bind_address)});
+    //spawn(proc() {connect(connect_addresses)});
+}
+
+fn parse_address(address: String) -> Option<Address> {
+    let hostport: Vec<&str> = address.as_slice().split(':').collect();
+    if hostport.len() < 2 {
+        None
+    } else {
+        let host = hostport[0];
+        let port: u16 = match from_str(hostport[1]) {
+            Some(port) => port,
+            None => {
+                println!("could not parse port");
+                return None;
+            }
+        };
+        Some((String::from_str(host), port))
+    }
+}
+
+#[test]
+fn foo() {
+    fn assert(expected: Option<Address>, actual: &str) {
+        let actual = parse_address(String::from_str(actual));
+        assert!(expected == actual);
     }
 
-    match args[1].as_slice() {
-        "server" => server::main(),
-        "client" => client::main(),
-        _        => usage(),
-    };
+    assert(None, "");
+    assert(None, "localhost");
+    assert(None, "8080");
+    assert(None, "localhost8080");
+    assert(None, "localhost:");
+    assert(Some((String::from_str("localhost"), 8080u16)), "localhost:8080");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,16 @@
 use std::os;
 use help::{usage, parse_address};
 
+mod server;
+mod client;
+
+static CLIENT_PING_PERIOD: u64 = 2000;
+
 type Address = (String, u16);
 
 fn main() {
     let mut args = os::args().move_iter();
-    
+
     let _          = args.next();
     let bind_addr  = args.next().expect(usage());
     let conn_addrs = args.collect();
@@ -17,15 +22,24 @@ fn network(bind_addr: String, conn_addrs: Vec<String>) {
     let conn_addrs = conn_addrs.move_iter().map(|s| {
         parse_address(s).expect(usage())
     }).collect();
-    
+
     _network(bind_addr, conn_addrs);
 }
 
 fn _network(bind_addr: Address, conn_addrs: Vec<Address>) {
-    let _ = bind_addr;
-    let _ = conn_addrs;
-    //spawn(proc() {serve(bind_addr)});
-    //spawn(proc() {connect(conn_addrs)});
+    let (host, port) = bind_addr;
+    let msg = format!("hello from {}:{}\n", host, port);
+
+    spawn(proc() {
+        server::serve(host.as_slice(), port);
+    });
+
+    for (host, port) in conn_addrs.move_iter() {
+        let msg = msg.clone();
+        spawn(proc() {
+            client::connect(host.as_slice(), port, msg.as_slice());
+        });
+    }
 }
 
 mod help {
@@ -35,10 +49,10 @@ mod help {
 
     pub fn parse_address(address: String) -> Option<super::Address> {
         let hostport: Vec<&str> = address.as_slice().split(':').collect();
-        
+
         if hostport.len() < 2 {
             return None
-        } 
+        }
 
         match (String::from_str(hostport[0]), from_str(hostport[1])) {
             (host, Some(port)) => Some((host, port)),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,9 @@
-use super::{SERVER_HOST, SERVER_PORT};
 use std::io::{TcpListener, TcpStream, Listener, Acceptor};
 use std::io::stdio;
 
-pub fn main() {
-    match TcpListener::bind(SERVER_HOST, SERVER_PORT).listen() {
+pub fn serve(host: &str, port: u16) {
+    println!("listening on {}:{}", host, port);
+    match TcpListener::bind(host, port).listen() {
         Ok(mut acceptor) => {
             for mut stream in acceptor.incoming() {
                 match stream {


### PR DESCRIPTION
We've written a simple client-server program where many clients can connect to a single server.

```
    C
    |
C - S - C
    |
    C
```

However, raft needs a set of servers to communicate with one another. 

```
S - S
| X |
S - S
```

This implements just that. 

Run `raft bind_adress [connect_address]...` on multiple machines to see it in action. For example, you could run

```
raft 127.0.0.1:8000 127.0.0.1:8001
```

on one machine and

```
raft 127.0.0.1:8001 127.0.0.1:8000
```

on another. The two machines will start talking to one another.

The next step for raft is to figure out capnp-proto's RPC's. Then, we'll plug in RPC's to this many-to-many communication to implement leader election.
